### PR TITLE
support for touching requester pays buckets

### DIFF
--- a/s3touch
+++ b/s3touch
@@ -7,6 +7,7 @@ var argv = require('minimist')(process.argv.slice(2), {
 var s3paths = argv._;
 var cache = {};
 var topic = null;
+var requesterPays = false;
 
 if (s3paths.length < 1) {
     console.log(s3touch.usage());
@@ -27,11 +28,12 @@ function run(err, data) {
         s3paths.shift();
     }
     if (s3paths.length) {
-        s3touch.touch(s3paths[0], cache, topic, run);
+        s3touch.touch(s3paths[0], cache, topic, requesterPays, run);
     }
 }
 
 if (argv.topic) topic = argv.topic;
+if (argv.requesterpays) requesterPays = true;
 
 if (argv.recursive) {
     s3touch.list(s3paths[0], function(err, list) {

--- a/test/test.js
+++ b/test/test.js
@@ -3,7 +3,7 @@ var s3touch = require('../index.js');
 var tape = require('tape');
 
 tape('usage', function(assert) {
-    assert.equal(s3touch.usage(), 'Usage: s3touch <s3 path> [--topic <ARN string>]');
+    assert.equal(s3touch.usage(), 'Usage: s3touch <s3 path> [--topic <ARN string>] [--requesterpays]');
     assert.end();
 });
 
@@ -19,7 +19,7 @@ tape('list', function(assert) {
 });
 
 tape('createMessage', function(assert) {
-    s3touch.createMessage('mapbox-pxm', 'travis-s3touch/a.txt', function(err, message) {
+    s3touch.createMessage('mapbox-pxm', 'travis-s3touch/a.txt', false, function(err, message) {
         assert.ifError(err);
         assert.equal(typeof message, 'object');
         assert.deepEqual(Object.keys(message), ['Records']);
@@ -37,28 +37,28 @@ tape('createMessage', function(assert) {
 });
 
 tape('touch: invalid url', function(assert) {
-    s3touch.touch('not-an-s3-url', {}, null, function(err) {
+    s3touch.touch('not-an-s3-url', {}, null, false, function(err) {
         assert.equal(err.toString(), 'Error: Invalid S3 path "not-an-s3-url"');
         assert.end();
     });
 });
 
 tape('touch: no pathname', function(assert) {
-    s3touch.touch('s3://bucketName', {}, null, function(err) {
+    s3touch.touch('s3://bucketName', {}, null, false, function(err) {
         assert.equal(err.toString(), 'Error: Invalid S3 path "s3://bucketName"');
         assert.end();
     });
 });
 
 tape('touch: head 404', function(assert) {
-    s3touch.touch('s3://mapbox-pxm/does-not-exist', {}, null, function(err) {
+    s3touch.touch('s3://mapbox-pxm/does-not-exist', {}, null, false, function(err) {
         assert.equal(err.toString(), 'Error: Could not HEAD object ("404")');
         assert.end();
     });
 });
 
 tape('touch: sends notification', function(assert) {
-    s3touch.touch('s3://mapbox-pxm/travis-s3touch/a.txt', {}, null, function(err, data) {
+    s3touch.touch('s3://mapbox-pxm/travis-s3touch/a.txt', {}, null, false, function(err, data) {
         assert.ifError(err);
         assert.equal(typeof data, 'object');
         assert.equal(typeof data.MessageId, 'string');
@@ -125,6 +125,14 @@ tape('bin: touch recursive', function(assert) {
 
 tape('bin: touch recursive with topic', function(assert) {
     exec(__dirname + '/../s3touch --recursive s3://mapbox-pxm/travis-s3touch --topic arn:aws:sns:us-east-1:234858372212:mapbox-pxm-s3-events', function(err, stdout, stderr) {
+        assert.equal(stdout, 'ok - s3://mapbox-pxm/travis-s3touch/a.txt\nok - s3://mapbox-pxm/travis-s3touch/b.txt\n');
+        assert.equal(stderr, '');
+        assert.end();
+    });
+});
+
+tape('bin: touch with requesterpays', function(assert) {
+    exec(__dirname + '/../s3touch s3://mapbox-pxm/travis-s3touch/a.txt --topic arn:aws:sns:us-east-1:234858372212:mapbox-pxm-s3-events --requesterpays', function(err, stdout, stderr) {
         assert.equal(stdout, 'ok - s3://mapbox-pxm/travis-s3touch/a.txt\nok - s3://mapbox-pxm/travis-s3touch/b.txt\n');
         assert.equal(stderr, '');
         assert.end();

--- a/test/test.js
+++ b/test/test.js
@@ -84,7 +84,7 @@ tape('bin: empty topic error and usage', function(assert) {
 });
 
 tape('bin: touch one with topic', function(assert) {
-    exec(__dirname + '/../s3touch s3://mapbox-pxm/travis-s3touch/a.txt --topic arn:aws:sns:us-east-1:234858372212:mapbox-pxm-s3-events', function(err, stdout, stderr) {
+    exec(__dirname + '/../s3touch s3://mapbox-pxm/travis-s3touch/a.txt --topic arn:aws:sns:us-east-1:234858372212:s3touch-tests', function(err, stdout, stderr) {
         assert.equal(stdout, 'ok - s3://mapbox-pxm/travis-s3touch/a.txt\n');
         assert.equal(stderr, '');
         assert.end();
@@ -108,7 +108,7 @@ tape('bin: touch multiple', function(assert) {
 });
 
 tape('bin: touch multiple with topic', function(assert) {
-    exec(__dirname + '/../s3touch s3://mapbox-pxm/travis-s3touch/a.txt s3://mapbox-pxm/travis-s3touch/b.txt --topic arn:aws:sns:us-east-1:234858372212:mapbox-pxm-s3-events', function(err, stdout, stderr) {
+    exec(__dirname + '/../s3touch s3://mapbox-pxm/travis-s3touch/a.txt s3://mapbox-pxm/travis-s3touch/b.txt --topic arn:aws:sns:us-east-1:234858372212:s3touch-tests', function(err, stdout, stderr) {
         assert.equal(stdout, 'ok - s3://mapbox-pxm/travis-s3touch/a.txt\nok - s3://mapbox-pxm/travis-s3touch/b.txt\n');
         assert.equal(stderr, '');
         assert.end();
@@ -124,16 +124,32 @@ tape('bin: touch recursive', function(assert) {
 });
 
 tape('bin: touch recursive with topic', function(assert) {
-    exec(__dirname + '/../s3touch --recursive s3://mapbox-pxm/travis-s3touch --topic arn:aws:sns:us-east-1:234858372212:mapbox-pxm-s3-events', function(err, stdout, stderr) {
+    exec(__dirname + '/../s3touch --recursive s3://mapbox-pxm/travis-s3touch --topic arn:aws:sns:us-east-1:234858372212:s3touch-tests', function(err, stdout, stderr) {
         assert.equal(stdout, 'ok - s3://mapbox-pxm/travis-s3touch/a.txt\nok - s3://mapbox-pxm/travis-s3touch/b.txt\n');
         assert.equal(stderr, '');
         assert.end();
     });
 });
 
-tape('bin: touch with requesterpays', function(assert) {
-    exec(__dirname + '/../s3touch s3://mapbox-pxm/travis-s3touch/a.txt --topic arn:aws:sns:us-east-1:234858372212:mapbox-pxm-s3-events --requesterpays', function(err, stdout, stderr) {
-        assert.equal(stdout, 'ok - s3://mapbox-pxm/travis-s3touch/a.txt\nok - s3://mapbox-pxm/travis-s3touch/b.txt\n');
+tape('bin: touch normal with requesterpays', function(assert) {
+    exec(__dirname + '/../s3touch s3://mapbox-pxm/travis-s3touch/a.txt --topic arn:aws:sns:us-east-1:234858372212:s3touch-tests --requesterpays', function(err, stdout, stderr) {
+        assert.equal(stdout, 'ok - s3://mapbox-pxm/travis-s3touch/a.txt\n');
+        assert.equal(stderr, '');
+        assert.end();
+    });
+});
+
+tape('bin: touch restricted without requesterpays', function(assert) {
+    exec(__dirname + '/../s3touch s3://aws-naip/md/2013/1m/rgbir/38077/m_3807708_ne_18_1_20130924.tif --topic arn:aws:sns:us-east-1:234858372212:s3touch-tests', function(err, stdout, stderr) {
+        assert.equal(stdout, '');
+        assert.equal(stderr, 'Error: Could not HEAD object ("403")\n');
+        assert.end();
+    });
+});
+
+tape('bin: touch restricted with requesterpays', function(assert) {
+    exec(__dirname + '/../s3touch s3://aws-naip/md/2013/1m/rgbir/38077/m_3807708_ne_18_1_20130924.tif --topic arn:aws:sns:us-east-1:234858372212:s3touch-tests --requesterpays', function(err, stdout, stderr) {
+        assert.equal(stdout, 'ok - s3://aws-naip/md/2013/1m/rgbir/38077/m_3807708_ne_18_1_20130924.tif\n');
         assert.equal(stderr, '');
         assert.end();
     });


### PR DESCRIPTION
Some buckets (notably `aws-naip`) use the requester pays header. This PR adds an option to support these buckets by passing the appropriate parameter to s3.HeadObject

Have not written tests yet. I just wanted to get a gut check about the implementation first. Manual testing works as expected:

``` bash
$ s3touch s3://aws-naip/md/2013/1m/rgbir/38077/m_3807708_ne_18_1_20130924.tif \
    --topic $SNSTOPIC
Error: Could not HEAD object ("403")

$ s3touch s3://aws-naip/md/2013/1m/rgbir/38077/m_3807708_ne_18_1_20130924.tif \
    --topic $SNSTOPIC --requesterpays
ok - s3://aws-naip/md/2013/1m/rgbir/38077/m_3807708_ne_18_1_20130924.tif
```

Thoughts @rclark ?
